### PR TITLE
.md ファイル名の制約を追加

### DIFF
--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -6,6 +6,8 @@ import html from 'remark-html'
 
 const postsDirectory: string = path.join(process.cwd(), 'posts')
 
+class InvalidIdError extends Error {}
+
 export interface PostSummary {
   id: string,
   title: string,
@@ -76,9 +78,20 @@ export async function getPost(id: string): Promise<Post> {
 }
 
 function loadRawPost(id: string): matter.GrayMatterFile<string> {
+  if (validateId(id)) {
+    throw new InvalidIdError
+  }
+
   const fullPath: string = path.join(postsDirectory, `${id}.md`)
   const fileContents: string = fs.readFileSync(fullPath, 'utf8')
   const RawPost = matter(fileContents)
 
   return RawPost
+}
+
+function validateId(id: string): Boolean {
+  const validateRegExp: RegExp = /(\w|-)+\.md/
+  const validResult = validateRegExp.test(id)
+
+  return validResult
 }

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -43,14 +43,15 @@ export function getSortedPostSummaries(): PostSummary[] {
 
 export function getAllPostIds(): { params: { id: string }}[] {
   const fileNames: string[] = fs.readdirSync(postsDirectory)
-
-  return fileNames.map(fileName => {
-    return {
-      params: {
-        id: fileName.replace(/\.md$/, '')
-      }
-    }
+  const allPostIds: { params: { id: string }}[] = fileNames.map(fileName => {
+    const id = fileName.replace(/\.md$/, '')
+    return { params: { id: id }}
   })
+  const validAllPostIds: { params: { id: string }}[] = allPostIds.filter(obj => {
+    return validateId(obj.params.id)
+  })
+
+  return validAllPostIds
 }
 
 export function getPostSummary(id: string): PostSummary {

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -79,7 +79,7 @@ export async function getPost(id: string): Promise<Post> {
 }
 
 function loadRawPost(id: string): matter.GrayMatterFile<string> {
-  if (validateId(id)) {
+  if (!validateId(id)) {
     throw new InvalidIdError
   }
 
@@ -91,7 +91,7 @@ function loadRawPost(id: string): matter.GrayMatterFile<string> {
 }
 
 function validateId(id: string): Boolean {
-  const validateRegExp: RegExp = /(\w|-)+\.md/
+  const validateRegExp: RegExp = /(\w|-)+/
   const validResult = validateRegExp.test(id)
 
   return validResult


### PR DESCRIPTION
## 関連 Issue

#6 

## やったこと

- .md ファイル名 (`id`) の制約を追加
- `getAllPostIds()` に有効な `id` だけ返却するフィルタを追加